### PR TITLE
Add specs for Google Nexus devices

### DIFF
--- a/screens.json
+++ b/screens.json
@@ -112,6 +112,27 @@
 		"ppi": 239
 	},
 	{
+		"name": "Google Nexus 4",
+		"w": 1280,
+		"h": 768,
+		"d": 4.7,
+		"ppi": 318
+	},
+	{
+		"name": "Google Nexus 7",
+		"w": 1280,
+		"h": 800,
+		"d": 7,
+		"ppi": 216
+	},
+	{
+		"name": "Google Nexus 10",
+		"w": 2560,
+		"h": 1600,
+		"d": 10.055,
+		"ppi": 300
+	},
+	{
 		"name": "Microsoft Surface RT",
 		"w": 1366,
 		"h": 768,


### PR DESCRIPTION
Sourced from:

http://www.google.co.uk/nexus/4/specs/ *
http://www.google.co.uk/nexus/7/specs/
http://www.google.co.uk/nexus/10/
- Rounds up the PPI to 320, but it's actually 318.
