### PR TITLE
fixed incorrect font src and font weight issue

### DIFF
--- a/style.css
+++ b/style.css
@@ -9,14 +9,14 @@
   font-family: 'Open Sans';
   font-style: normal;
   font-weight: 400;
-  src: local('Open Sans'), local('OpenSans'), url(onts/open-sans-regular.woff) format('woff');
+  src: local('Open Sans'), local('OpenSans'), url(fonts/open-sans-regular.woff) format('woff');
 }
 
 @font-face {
   font-family: 'Open Sans';
   font-style: normal;
   font-weight: 700;
-  src: local('Open Sans Bold'), local('OpenSans-Bold'), url(onts/open-sans-bold.woff) format('woff');
+  src: local('Open Sans Bold'), local('OpenSans-Bold'), url(fonts/open-sans-bold.woff) format('woff');
 }
 
 body {
@@ -108,6 +108,10 @@ select {
 	appearance: none;
 	background: transparent;
 	border: 0;
+}
+
+strong {
+	font-weight:700;
 }
 
 output {


### PR DESCRIPTION
before: 
![screen shot 2013-06-10 at 9 38 38 am](https://f.cloud.github.com/assets/3824954/631846/7611278a-d1d4-11e2-8e38-e6740c1d18a4.png)

after: 
![screen shot 2013-06-10 at 9 45 41 am](https://f.cloud.github.com/assets/3824954/631847/7b16c276-d1d4-11e2-8edc-b5ad9e272950.png)

by adding font-weight:700 to `<strong>` the browser doesn't try to do do this faux rendering, where the font looks doubled. 

Demo here: http://jshawl.github.io/dpi/
