### PR TITLE
Revise Retina reference on FAQ

### DIFF
--- a/index.html
+++ b/index.html
@@ -97,7 +97,7 @@
 		<p>There are arguments for both terms. In general PPI is a bit more correct but DPI is more commonplace, hence its usage on this site (also ppi.lv wasn’t available :P). 
 		If you are interested, you can read more on this in the <a href="http://en.wikipedia.org/wiki/Pixel_density">Wikipedia article about Pixel Density</a>.</p>
 		
-		<p>In more recent terminology, DPI is often used for the actual device pixels and Dots Per Pixel (dppx) for the amount of device pixels per CSS pixel (e.g. in Retina displays this will be 2).</p>
+		<p>In more recent terminology, DPI is often used for the actual device pixels and Dots Per Pixel (dppx) for the amount of device pixels per CSS pixel (e.g. for the Retina iPhone this will be 2).</p>
 	</article>
 	
 	<article>


### PR DESCRIPTION
Apple's Retina is defined by pixels per viewing degree (i.e., some ppi / estimated viewing distance = Retina), so Retina devices have varying ppi/dppx. Revised the reference in the FAQ to a device that has 2dppx.
