### PR TITLE
Decode location.hash before using

### DIFF
--- a/dpi.js
+++ b/dpi.js
@@ -104,8 +104,10 @@ function deviceRow(device, fragment) {
 
 
 (window.onhashchange = function() {
-	if (hashRegex.test(location.hash)) {
-		var matches = location.hash.match(hashRegex);
+	var hash = decodeURIComponent(location.hash);
+	
+	if (hashRegex.test(hash)) {
+		var matches = hash.match(hashRegex);
 		
 		if (matches[1]) {
 			width.value = matches[1]


### PR DESCRIPTION
This fixes #41 for Safari, while I'm still not sure whether it's doing the wrong thing or the right thing with regards to this (?).

Calling decodeURIComponent() on the hash in Chrome, Firefox & Opera (which have all decoded the hash before returning it) doesn't have any sideeffects, it seems.
