### PR TITLE
New formatting for searches of iPhone 4(S) and 3G(S)

### DIFF
--- a/screens.json
+++ b/screens.json
@@ -7,7 +7,7 @@
 		"dppx": 2
 	},
 	{
-		"name": "Apple iPhone 4(S)",
+		"name": "Apple iPhone 4, 4S",
 		"w": 960,
 		"h": 640,
 		"d": 3.5,
@@ -15,7 +15,7 @@
 		"dppx": 2
 	},
 	{
-		"name": "Apple iPhone 1 & 3G(S)",
+		"name": "Apple iPhone 1, 3G, 3GS",
 		"w": 320,
 		"h": 480,
 		"d": 3.5,


### PR DESCRIPTION
Made simple text changes for user-friendly "iPhone 4(S)" and "3G(S)" searches.
