### PR TITLE
Add Motorola Moto G.

### DIFF
--- a/screens.json
+++ b/screens.json
@@ -291,6 +291,15 @@
 		"d": 10.6
 	},
 	{
+		"name": "Motorola Moto G",
+		"w": 720,
+		"h": 1280,
+		"d": 4.5,
+		"ppi": 326,
+		"dpi": 192,
+		"dppx": 2
+	},
+	{
 		"name": "Samsung Galaxy Tab 7.0 Plus",
 		"w": 600,
 		"h": 1024,


### PR DESCRIPTION
Hello Lea,

I just wanted to add the specifications of the _Moto G_ by _Motorola_.

But before I've written down the JSON, I checked the window-object of my mobile firefox/chrome and it tells different attributes to the physical ones:
So the dpi is `192`, while the physical ppi is `326`.

If you want to add the `dpi` of the window-object to your list, I added it to the JSON.
