### PR TITLE
Remove duplicate

### DIFF
--- a/screens.json
+++ b/screens.json
@@ -299,12 +299,6 @@
 		"d": 3.2
 	},
 	{
-		"name": "Microsoft Surface RT",
-		"w": 1366,
-		"h": 768,
-		"d": 10.6
-	},
-	{
 		"name": "Lenovo ideapad U310",
 		"w": 1366,
 		"h": 768,


### PR DESCRIPTION
Microsoft Surface RT and Microsoft Surface are listed twice.   They are the same product since Microsoft only build two tablets: Microsoft Surface (RT) and Surface Pro.   

On Microsoft [sites](http://www.microsoft.com/surface/en-us/products/overview), they are listed as [Surface and Surface 2](http://www.microsoftstore.com/store/msusa/en_US/html/pbPage.CATS/categoryID.66734700).  Some may still refer to the first/original Surface as Surface RT, but since on Microsoft pages it's not listed as RT it's probably better to remove the RT; especially since they are one and the same.
