### PR TITLE
Corrected Google Nexus 9 dppx from 1 to 2

### DIFF
--- a/screens.json
+++ b/screens.json
@@ -322,7 +322,8 @@
 		"name": "Google Nexus 9",
 		"w": 2048,
 		"h": 1536,
-		"d": 8.9
+		"d": 8.9,
+		"dppx": 2
 	},
 	{
 		"name": "Google Nexus 10",


### PR DESCRIPTION
The Google Nexus 9 has a css pixel ratio of 2, not 1.

http://mydevice.io/devices/
