### PR TITLE
Table and Resolution Select Improvements

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,8 +26,10 @@
 	<p id="resolutions">Common: 
 		<a href="#" tabindex="-1">1920×1080</a>
 		<a href="#" tabindex="-1">1680×1050</a>
+		<a href="#" tabindex="-1">1680×900</a>
 		<a href="#" tabindex="-1">1440×900</a>
 		<a href="#" tabindex="-1">1366×768</a>
+		<a href="#" tabindex="-1">1360×768</a>
 		<a href="#" tabindex="-1">1280×800</a>
 		<a href="#" tabindex="-1">1386×768</a>
 		<a href="#" tabindex="-1">1024×768</a>
@@ -72,10 +74,10 @@
 			<thead>
 				<tr>
 					<th>Name</th>
-					<th>Diagonal</th>
+					<th>Diagonal (inches)</th>
 					<th>Resolution</th>
-					<th>DPI</th>
-					<th>dppx</th>
+					<th><span title="Dots Per Inch">DPI</span></th>
+					<th><span title="Dots Per Pixel Unit">dppx</span></th>
 				</tr>
 			</thead>
 			<tbody>

--- a/index.html
+++ b/index.html
@@ -74,10 +74,10 @@
 			<thead>
 				<tr>
 					<th>Name</th>
-					<th>Diagonal (inches)</th>
+					<th title="(inches)">Diagonal</th>
 					<th>Resolution</th>
-					<th><span title="Dots Per Inch">DPI</span></th>
-					<th><span title="Dots Per Pixel Unit">dppx</span></th>
+					<th title="Dots Per Inch">DPI</th>
+					<th title="Dots Per Pixel Unit">dppx</th>
 				</tr>
 			</thead>
 			<tbody>


### PR DESCRIPTION
I've edited the table so that the column titles are more descriptive, and hovering over the acronyms results in a small OS-independant pop-up.

I've also added some more common screen resolutions - I noticed a few were missing that I've used in the past.
