### PR TITLE
Fix OnePlus One dppx

### DIFF
--- a/screens.json
+++ b/screens.json
@@ -619,7 +619,8 @@
 		"name": "OnePlus One",
 		"w": 1080,
 		"h": 1920,
-		"d": 5.5
+		"d": 5.5,
+		"dppx": 3
 	},
 	{
 		"name": "Samsung Galaxy S6, S6 Edge",


### PR DESCRIPTION
I just checked, and the OPO has 3 dppx, not 1 (this would look really funny anyway one a 1080x1920 screen).
