### PR TITLE
Set DPPX values for Samsung Galaxy S6 and S2.

### DIFF
--- a/screens.json
+++ b/screens.json
@@ -626,7 +626,8 @@
 		"w": 1440,
 		"h": 2560,
 		"d": 5.1,
-		"ppi": 577
+		"ppi": 577,
+		"dppx": 4
 	},
 	{
 		"name": "Samsung Galaxy S3",
@@ -640,7 +641,8 @@
 		"w": 480,
 		"h": 800,
 		"d": 4.3,
-		"ppi": 217
+		"ppi": 217,
+		"dppx": 1.5
 	},
 	{
 		"name": "Samsung Galaxy S",


### PR DESCRIPTION
Added DPPX values for:
- Samsung Galaxy S6
- Samsung Galaxy S2
