### PR TITLE
Fixed invalid JSON

### DIFF
--- a/screens.json
+++ b/screens.json
@@ -395,7 +395,7 @@
 		"name": "Dell Precision 5510",
 		"w": 3840,
 		"h": 2160,
-		"d": 15.6,
+		"d": 15.6
 	},
 	{
 		"name": "Dell SP2309W",


### PR DESCRIPTION
Noticed that http://dpi.lv is broken due to JSON trailing comma in screens.js