### PR TITLE
Update dppx for iPhone 6 Plus / 6s  Plus / 7 Plus

### DIFF
--- a/screens.json
+++ b/screens.json
@@ -181,7 +181,7 @@
 		"h": 1920,
 		"d": 5.5,
 		"ppi": 401,
-		"dppx": 2.46
+		"dppx": 3
 	},
 	{
 		"name": "Apple iPhone X",


### PR DESCRIPTION
Updated to the reported value according to [Window.devicePixelRatio](https://developer.mozilla.org/en-US/docs/Web/API/Window/devicePixelRatio).

[This article](https://medium.com/we-are-appcepted/the-curious-case-of-iphone-6-1080p-display-b33dac5bbcb6) does a terrific job of explaining all the details of how Apple scales the display resolution. The computed value of viewport to _physical_ dimension is approximately 2.6087, but the _virtual_ ratio is 3.0.