### PR TITLE
Correction to devices.json

### DIFF
--- a/devices.json
+++ b/devices.json
@@ -1437,9 +1437,9 @@
 			"name": "OnePlus 7T Pro 5G McLaren on T-Mobile",
 			"w": 1440,
 			"h": 3120,
-			"d": 6.567,
+			"d": 6.67,
 			"ppi": 515,
-			"dppx": "?"
+			"dppx": 3.5
 		}
 	],
 	"dimension": "d"


### PR DESCRIPTION
Fat fingered an extra 5 in the diagonal screen size for the OnePlus 7T Pro 5G McLaren on T-Mobile. 

Corrected to 6.67.

Found out from another website what the DPPX is at 3.5.

Reference: https://yesviz.com/devices/oneplus-7t-pro/